### PR TITLE
chore: enforce one child issue per PR

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,7 @@
 ## Linked Issue
 
 Closes #
+Refs #
 
 ## Summary
 

--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -17,6 +17,8 @@ jobs:
           import sys
 
           body = os.environ.get("PR_BODY", "")
+          closes = body.count("Closes #")
+          refs = body.count("Refs #")
           required_sections = [
               "## Linked Issue",
               "## Summary",
@@ -27,8 +29,10 @@ jobs:
           ]
 
           missing = [section for section in required_sections if section not in body]
-          if "Closes #" not in body and "Refs #" not in body:
-              missing.append("issue reference (`Closes #` or `Refs #`)")
+          if closes != 1:
+              missing.append("exactly one closing child issue (`Closes #`)")
+          if refs > 1:
+              missing.append("at most one parent/reference issue (`Refs #`)")
 
           if missing:
               print("PR body is missing required content:")


### PR DESCRIPTION
## Linked Issue

Closes #14

## Summary

This PR tightens the repository workflow so a PR can close exactly one child issue and optionally reference one parent issue. It updates the PR template and PR hygiene workflow to enforce the intended issue decomposition policy.

## Acceptance Criteria Coverage

- [x] issue acceptance criteria reviewed
- [x] this PR covers the intended scope without unrelated changes

The PR template now supports one closing issue line and one optional parent reference line, and PR hygiene fails if a PR tries to close multiple child issues.

## Validation

- [x] uff check .
- [x] mypy .
- [x] pytest -q
- [ ] manual smoke check completed when runtime behavior changed

Workflow-only change. Manual runtime smoke check was not needed.

## AI Review Findings Summary

- [x] local AI review completed for this non-trivial change
- [x] findings were fixed or explicitly accepted

No findings.

## Declarative Design

- [x] implementation stays declarative by default
- [x] any imperative code is limited to an integration boundary and justified below

This change is policy and workflow enforcement only.

## Risks / Rollback

Low risk. Rollback is straightforward: revert the PR template and workflow check if the policy proves too strict.

No added support burden.