### PR TITLE
test: add voice rendering coverage

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -44,3 +44,12 @@ def test_salute_auth_key_not_required_for_silero_only(monkeypatch: pytest.Monkey
 
     assert cfg.tts_provider == "silero"
     assert cfg.tts_fallback_provider == ""
+
+
+def test_speech_chunk_limit_is_loaded_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENCLAW_GATEWAY_TOKEN", "x")
+    monkeypatch.setenv("SPEECH_MAX_CHUNK_CHARS", "123")
+
+    cfg = VoiceConfig.from_env()
+
+    assert cfg.speech_max_chunk_chars == 123

--- a/tests/test_tts_service.py
+++ b/tests/test_tts_service.py
@@ -4,8 +4,9 @@ from dataclasses import dataclass
 from pathlib import Path
 from unittest.mock import Mock
 
+from openclaw_voice.config import VoiceConfig
 from openclaw_voice.services.speech_shaper import RussianSpeechShaper
-from openclaw_voice.services.tts_service import TTSService
+from openclaw_voice.services.tts_service import TTSService, build_tts_service
 
 
 @dataclass
@@ -91,3 +92,44 @@ def test_shaper_splits_long_markdown_like_reply() -> None:
     assert all(len(chunk) <= 35 for chunk in chunks)
     assert not any("https://" in chunk for chunk in chunks)
     assert not any("[" in chunk for chunk in chunks)
+
+
+def test_build_tts_service_uses_silero_primary_and_shaper_limit() -> None:
+    config = VoiceConfig(
+        openclaw_gateway_url="http://localhost:18789",
+        openclaw_gateway_token="token",
+        openclaw_agent_id="main",
+        wake_word="jarvis",
+        wake_sensitivity=0.6,
+        silence_seconds=1.5,
+        history_limit=20,
+        tts_provider="silero",
+        tts_fallback_provider="",
+        speech_max_chunk_chars=77,
+    )
+
+    service = build_tts_service(config)
+
+    assert service.primary_provider.name == "silero"
+    assert service.fallback_provider is None
+    assert isinstance(service.shaper, RussianSpeechShaper)
+    assert service.shaper.max_chunk_chars == 77
+
+
+def test_build_tts_service_skips_duplicate_fallback_provider() -> None:
+    config = VoiceConfig(
+        openclaw_gateway_url="http://localhost:18789",
+        openclaw_gateway_token="token",
+        openclaw_agent_id="main",
+        wake_word="jarvis",
+        wake_sensitivity=0.6,
+        silence_seconds=1.5,
+        history_limit=20,
+        tts_provider="silero",
+        tts_fallback_provider="silero",
+    )
+
+    service = build_tts_service(config)
+
+    assert service.primary_provider.name == "silero"
+    assert service.fallback_provider is None


### PR DESCRIPTION
## Linked Issue
Closes #11
Refs #6

## Summary
- add explicit tests for Silero-first provider selection through uild_tts_service
- cover the shaping chunk limit loaded from environment config
- keep this PR test-only with no runtime behavior changes

## Acceptance Criteria Coverage
- provider selection for the Silero-first runtime is covered
- fallback behavior remains covered through the provider contract tests
- spoken-response shaping behavior remains covered without real cloud credentials

## Validation
- pre-commit run detect-secrets --all-files --show-diff-on-failure
- ruff check .
- mypy .
- pytest -q

## AI Review Findings Summary
- no findings
- tests stay declarative and exercise contracts instead of provider internals

## Risks / Rollback
- low risk: test-only change
- rollback: revert PR if any assertion proves too brittle
- No added support burden