### PR TITLE
fix: declare Silero runtime dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
   "RealtimeSTT",
   "pvporcupine",
   "pygame",
+  "omegaconf",
   "requests",
   "python-dotenv",
   "soundfile",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 RealtimeSTT
 pvporcupine
 pygame
+omegaconf
 requests
 python-dotenv
+soundfile

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+
+def test_silero_runtime_dependencies_are_declared_in_pyproject() -> None:
+    pyproject = Path("pyproject.toml")
+    data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    dependencies = set(data["project"]["dependencies"])
+
+    assert "omegaconf" in dependencies
+    assert "soundfile" in dependencies
+
+
+def test_requirements_txt_includes_silero_runtime_dependencies() -> None:
+    requirements = {
+        line.strip()
+        for line in Path("requirements.txt").read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.startswith("#")
+    }
+
+    assert "omegaconf" in requirements
+    assert "soundfile" in requirements


### PR DESCRIPTION
## Linked Issue
Closes #23

## Summary
- add the missing omegaconf runtime dependency required by the Silero model bootstrap path
- keep equirements.txt aligned with the package dependency declaration
- add a regression test that fails if the Silero runtime dependency declaration regresses again

## Acceptance Criteria Coverage
- omegaconf is now declared in the runtime dependencies required for Silero
- install flows that rely on the package metadata or equirements.txt now include the dependency
- tests now fail if the Silero runtime dependency declaration is missing in the future
- local validation passes after the packaging fix

## Validation
- pre-commit run detect-secrets --all-files --show-diff-on-failure
- ruff check .
- mypy .
- pytest -q

## AI Review Findings Summary
- one real packaging gap was confirmed by the manual runtime smoke test: Silero failed with No module named 'omegaconf'
- added a packaging-focused regression test so this class of bug is caught by CI before manual verification

## Risks / Rollback
- low risk: dependency declaration and test-only enforcement
- rollback: revert this PR if dependency resolution behaves unexpectedly
- No added support burden