### PR TITLE
feat: keep Silero as fallback mode (#30)

### DIFF
--- a/docs/voice-architecture.md
+++ b/docs/voice-architecture.md
@@ -25,6 +25,8 @@
 2. Set `OPENCLAW_GATEWAY_TOKEN`.
 3. Keep `TTS_PROVIDER=silero` for the default local setup.
 4. Leave `TTS_FALLBACK_PROVIDER=` empty unless you add another provider later.
+   If you add a premium provider, set `TTS_FALLBACK_PROVIDER=silero` so the bridge
+   can fall back to the local mode when the premium path fails.
 5. Adjust `SILERO_*` values only if you intentionally want a different model or speaker.
 6. Use `SPEECH_MAX_CHUNK_CHARS` to control how aggressively long replies are split before playback.
 7. Set `WAKEWORD_BACKEND` explicitly (`pvporcupine` or `openwakeword`).
@@ -33,6 +35,11 @@
 10. Use `VOICE_SESSION_MODE=continuous` to enable follow-up turns without repeating the wake word.
 11. Tune `SESSION_IDLE_TIMEOUT_SEC` to decide when an idle conversation returns to single-turn mode.
 12. Keep `STOP_INTENT_ENABLED=true` and customize `STOP_INTENT_PHRASES` to allow a spoken exit (include your target language phrases).
+
+## Fallback Mode
+Silero remains the baseline local fallback. It is reliable and installable without
+API keys, but it is not UX‑equivalent to a premium voice provider. Use it as the
+safe fallback path and expect lower naturalness than cloud voices.
 
 ## Smoke Test
 - Run `python scripts/smoke_test_voice.py --skip-bridge-run` for the local-first configuration checks.

--- a/openclaw_voice/services/tts_service.py
+++ b/openclaw_voice/services/tts_service.py
@@ -117,6 +117,12 @@ def build_tts_service(config: VoiceConfig) -> TTSService:
         if config.tts_fallback_provider and config.tts_fallback_provider != config.tts_provider
         else None
     )
+    if fallback_provider is not None:
+        LOGGER.info(
+            "tts_fallback_configured primary=%s fallback=%s",
+            primary_provider.name,
+            fallback_provider.name,
+        )
     shaper = RussianSpeechShaper(max_chunk_chars=config.speech_max_chunk_chars)
     return TTSService(
         primary_provider=primary_provider,


### PR DESCRIPTION
## Linked Issue
Closes #30
Refs #28

## Summary
- Log when a TTS fallback is configured.
- Document how and when to use Silero as a fallback mode.
- Clarify that fallback is functional but not UX-equivalent to premium voices.

## Acceptance Criteria Coverage
- Silero remains available as a fallback/local mode, documented in the runtime setup and fallback section.
- Fallback behavior is explicit and logged when configured.
- Fallback mode is still installable/testable (no new dependencies required).
- Docs state fallback is functional but not UX-equivalent to premium path.

## Validation
- `ruff check .`
- `mypy .`
- `pytest -q`

## AI Review Findings Summary
- No correctness regressions found.
- Change is documentation + logging only.

## Risks / Rollback
- Low risk: log line and docs only.
- Rollback: revert this PR to restore prior behavior.

## Notes
- `pre-commit run detect-secrets --all-files` still fails locally with `PermissionError` when creating the pre-commit cache (WinError 5).
