### PR TITLE
chore: enforce structured GitHub issue governance

### DIFF
--- a/.github/ISSUE_TEMPLATE/child_task.yml
+++ b/.github/ISSUE_TEMPLATE/child_task.yml
@@ -1,0 +1,78 @@
+name: Child task
+description: Create a decomposed task under an existing epic with explicit order and dependencies.
+title: "[1/1] "
+labels: ["type:feature", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for any issue that belongs to a larger epic.
+
+        A child task without a parent, order, dependencies, current action, and acceptance criteria is not correctly formed for this repository.
+  - type: input
+    id: parent_issue
+    attributes:
+      label: Parent issue
+      description: Reference the master issue or epic, for example `#36`.
+      placeholder: "#36"
+    validations:
+      required: true
+  - type: input
+    id: phase_order
+    attributes:
+      label: Phase / Order
+      description: Use a title prefix like `[1/6]`, `[2/6]`, or `[Phase 2]`.
+      placeholder: "[1/6]"
+    validations:
+      required: true
+  - type: input
+    id: depends_on
+    attributes:
+      label: Depends on
+      description: List blocking issues, or write `none` if this is the first step.
+      placeholder: "#45"
+    validations:
+      required: true
+  - type: input
+    id: blocks
+    attributes:
+      label: Blocks
+      description: List downstream issues blocked by this task, if any.
+      placeholder: "#46, #47"
+  - type: textarea
+    id: current_action
+    attributes:
+      label: Current action
+      description: State what should be done now and whether later tasks must wait.
+    validations:
+      required: true
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: What narrow outcome does this task deliver?
+    validations:
+      required: true
+  - type: textarea
+    id: non_goals
+    attributes:
+      label: Non-goals
+      description: State what this issue must not implement.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+  - type: textarea
+    id: risks
+    attributes:
+      label: Risks / constraints
+      description: Capture sequencing risks, contract constraints, or migration caveats.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -1,0 +1,58 @@
+name: Epic
+description: Create or update a master issue for a multi-step feature or refactor.
+title: "[Epic] "
+labels: ["type:feature", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for any multi-step feature, refactor, or roadmap item.
+
+        Every epic must include a roadmap, execution order, and a clear statement of what should be done now.
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: What end state should this epic achieve?
+    validations:
+      required: true
+  - type: textarea
+    id: user_value
+    attributes:
+      label: User value
+      description: What user or operator benefit does this epic deliver?
+    validations:
+      required: true
+  - type: textarea
+    id: roadmap
+    attributes:
+      label: Roadmap
+      description: List child issues in execution order using a task checklist.
+      placeholder: |
+        - [ ] #123 [1/4] ...
+        - [ ] #124 [2/4] ...
+    validations:
+      required: true
+  - type: textarea
+    id: current_action
+    attributes:
+      label: Current action
+      description: State exactly what should be worked on now and what should not start yet.
+    validations:
+      required: true
+  - type: textarea
+    id: final_acceptance
+    attributes:
+      label: Final acceptance criteria
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+  - type: textarea
+    id: risks
+    attributes:
+      label: Risks / constraints
+      description: Capture key constraints, blockers, or sequencing risks.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,8 +1,14 @@
 name: Feature request
-description: Capture a user-facing change as a scoped task.
+description: Capture a standalone single-step feature that is not part of a larger epic.
 title: "feature: "
 labels: ["type:feature", "needs-triage"]
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form only for a truly atomic standalone task.
+
+        If the work is part of a multi-step feature, create or update an epic and use the Child task form instead.
   - type: textarea
     id: goal
     attributes:
@@ -16,6 +22,16 @@ body:
       label: User value
     validations:
       required: true
+  - type: dropdown
+    id: issue_scope
+    attributes:
+      label: Issue type
+      description: Multi-step work must use an epic plus child tasks instead of this form.
+      options:
+        - Standalone single-step task
+        - Part of a larger epic
+    validations:
+      required: true
   - type: textarea
     id: scope
     attributes:
@@ -27,10 +43,20 @@ body:
     id: out_of_scope
     attributes:
       label: Out of scope
+    validations:
+      required: true
+  - type: textarea
+    id: current_action
+    attributes:
+      label: Current action
+      description: State what should be done now in one or two sentences.
+    validations:
+      required: true
   - type: textarea
     id: implementation_notes
     attributes:
       label: Implementation notes
+      description: If this turns out to be part of a larger epic, stop and convert it into an epic plus child tasks.
   - type: textarea
     id: acceptance
     attributes:
@@ -44,3 +70,4 @@ body:
     id: risks
     attributes:
       label: Risks
+      description: Note blockers, dependencies, or reasons this issue should remain standalone.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,26 @@
+# GitHub Copilot Repository Instructions
+
+## Issue Structure Policy
+- Treat issue structure as mandatory workflow, not optional guidance.
+- For any multi-step feature, refactor, or roadmap item, first create or update a master issue / epic.
+- Every child issue under an epic must include:
+  - `Parent: #...`
+  - `Depends on: ...`
+  - `Blocks: ...` when applicable
+  - `Current action`
+  - `Goal`
+  - `Non-goals`
+  - `Acceptance criteria`
+- Every epic must contain a `## Roadmap` checklist listing child issues in execution order.
+- Ordered task chains must use title prefixes such as `[1/6]`, `[2/6]`, `[Phase 2]`, `[Phase 3]`, or `[Later]`.
+- When execution order changes, update both the parent roadmap and the dependency fields on child issues.
+- Prefer atomic issues with one responsibility each: config, contracts, provider, playback, concurrency, docs, or tests.
+- Do not create broad mixed-scope issues that combine multiple responsibilities unless explicitly requested and justified.
+- If a new issue belongs to an epic, use the child task form instead of the standalone feature form.
+
+## Naming Conventions
+- Use `[Epic] ...` for top-level cross-cutting work.
+- Use `[Phase N Epic] ...` for the currently active major delivery stream.
+- Use `[N/M] ...` for linear child tasks.
+- Use `[Phase N] ...` for ordered follow-up phases.
+- Use `[Later] ...` for intentionally deferred work.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,20 @@ This repository uses these rules for any AI coding assistant session.
 
 ## Change Process
 - Treat GitHub Issues as the system of record for bugs, features, and tech debt.
+- For any multi-step feature or refactor, create or update a master issue / epic before creating implementation tasks.
+- Every child issue under an epic must include:
+  - `Parent: #...`
+  - `Depends on: ...`
+  - `Blocks: ...` when applicable
+  - `Current action`
+  - `Goal`
+  - `Non-goals`
+  - `Acceptance criteria`
+- Every epic must include a `## Roadmap` checklist listing child issues in execution order.
+- Ordered implementation chains must use title prefixes such as `[1/6]`, `[2/6]`, `[Phase 2]`, or `[Later]`.
+- When changing execution order or scope, update the parent roadmap and dependency fields, not just the child issue text.
+- Prefer atomic issues with one responsibility each; do not combine config, contracts, implementation, tests, and docs in one issue unless explicitly justified.
+- If an issue grows beyond a single responsibility, split it into smaller issues instead of continuing to expand it.
 - Use chat for discussion only; persist accepted work items in Issues.
 - Link non-trivial changes to an Issue and keep acceptance criteria there.
 - Use GitHub PRs as the system of record for code review, validation evidence, and merge decisions.


### PR DESCRIPTION
﻿## Linked Issue

Closes #52
Refs #36

## Summary
This PR turns structured GitHub issue governance into a repository rule instead of a recommendation. It adds repository-level Copilot instructions, codifies the same policy in `AGENTS.md`, and introduces dedicated Epic and Child task forms while narrowing standalone feature requests to atomic work.

## Acceptance Criteria Coverage

- [x] issue acceptance criteria reviewed
- [x] this PR covers the intended scope without unrelated changes

This PR adds `.github/copilot-instructions.md` with mandatory issue-structure rules, updates `AGENTS.md` to require epic-first and child-task dependency structure, adds `.github/ISSUE_TEMPLATE/epic.yml`, adds `.github/ISSUE_TEMPLATE/child_task.yml`, narrows `.github/ISSUE_TEMPLATE/feature_request.yml` to standalone single-step work, and keeps terminology aligned across policy and forms.

## Validation

- [ ] `ruff check .`
- [ ] `mypy .`
- [ ] `pytest -q`
- [x] manual smoke check completed when runtime behavior changed

This change only touches repository instructions and GitHub issue templates. I manually reviewed the updated files for terminology consistency across `Parent`, `Depends on`, `Blocks`, `Current action`, and `Roadmap`.

## AI Review Findings Summary

- [x] local AI review completed for this non-trivial change
- [x] findings were fixed or explicitly accepted

No findings.

## Declarative Design

- [x] implementation stays declarative by default
- [x] any imperative code is limited to an integration boundary and justified below

The change is declarative repository policy and template configuration. No new runtime imperative control flow was introduced.

## Risks / Rollback

Main risk is workflow friction if the issue forms are too strict for some contributors. Rollback is straightforward: revert the policy text in `AGENTS.md` and `.github/copilot-instructions.md`, and remove or relax the new issue forms.

No added support burden.
